### PR TITLE
updated git clone commands to pull from master branch

### DIFF
--- a/service-configuration/service-configuration-demo/packer/files/install_webclient.sh
+++ b/service-configuration/service-configuration-demo/packer/files/install_webclient.sh
@@ -9,7 +9,5 @@ pip3 install pymongo
 rm -rf /home/ubuntu/src && mkdir -p /home/ubuntu/src
 cd /tmp
 git clone https://github.com/hashicorp/consul-guides.git
-# PR only step:
-cd consul-guides && git fetch && git checkout add-service-configuration && cd ..
 cp -r /tmp/consul-guides/service-configuration/service-configuration-demo/application/simple-client /home/ubuntu/src
 chown -R ubuntu:ubuntu /home/ubuntu/src/simple-client

--- a/service-configuration/service-configuration-demo/terraform/aws/README.md
+++ b/service-configuration/service-configuration-demo/terraform/aws/README.md
@@ -37,7 +37,6 @@ export AWS_DEFAULT_REGION="us-east-1"
 Replace `<your access key ID>` with your AWS Access Key ID and `<your secret key>` with your AWS Secret Access Key (see [Access Keys (Access Key ID and Secret Access Key)](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys) for more help). *NOTE*: Currently, the pre-built Packer AMIs are in `us-east-1` and `us-west-1` region.
 
 2. Please run: `git clone https://github.com/hashicorp/consul-guides.git`  
-   _[PR only step: `cd consul-guides && git fetch && git checkout add-service-configuration && cd ..`]_
 3. `cd consul-guides/service-configuration/service-configuration-demo/terraform/aws/`
 4. `cp terraform.auto.tfvars.example terraform.auto.tfvars`
 5. Edit the `terraform.auto.tfvars` file:

--- a/service-configuration/service-configuration-demo/terraform/aws/init_listing.tpl
+++ b/service-configuration/service-configuration-demo/terraform/aws/init_listing.tpl
@@ -7,8 +7,6 @@ systemctl stop listing.service
 # Download application
 cd /tmp
 git clone https://github.com/hashicorp/consul-guides.git
-# PR only step:
-cd consul-guides && git fetch && git checkout add-service-configuration && cd ..
 cp -r /tmp/consul-guides/service-configuration/service-configuration-demo/application/listing-service /opt
 
 # Create application directory and create a PID file:

--- a/service-configuration/service-configuration-demo/terraform/aws/init_products.tpl
+++ b/service-configuration/service-configuration-demo/terraform/aws/init_products.tpl
@@ -10,8 +10,6 @@ pip3 install hvac
 # Download application
 cd /tmp
 git clone https://github.com/hashicorp/consul-guides.git
-# PR only step:
-cd consul-guides && git fetch && git checkout add-service-configuration && cd ..
 cp -r /tmp/consul-guides/service-configuration/service-configuration-demo/application/product-service /opt
 
 # Create application directory and create a PID file:


### PR DESCRIPTION
This PR updates service configuration demo to pull application code from master branch via `git clone commands`. These are a few places where this occurs:
- README.md steps for running the demo
- EC2 user-data initialization for listing and product service
- Packer install script for web-client service. Updated packer builds for web-client are already availabel in `us-east-1` and `us-west-1`